### PR TITLE
Disable the local build of htslib if HTSLIB_DIR is provided

### DIFF
--- a/tools/cmake/IncludeHtslib.cmake
+++ b/tools/cmake/IncludeHtslib.cmake
@@ -26,7 +26,9 @@
 # This file is included from the main CMakeLists.txt in order to build htslib.
 message (STATUS "Looking for htslib")
 cmake_minimum_required( VERSION 3.1 )
-include(ExternalProject)
+if(NOT DEFINED HTSLIB_DIR)
+  include(ExternalProject)
+endif()
 
 # ==================================================================================================
 #   Check for autotools
@@ -195,7 +197,8 @@ endif()
 
 # We download and built on our own, using the correct commit hash to get our exact desired
 # version, and install locally to the build directory.
-ExternalProject_Add(
+if(NOT DEFINED HTSLIB_DIR)
+  ExternalProject_Add(
     htslib
     PREFIX ""
 
@@ -243,11 +246,14 @@ ExternalProject_Add(
 
     # Install Step
     INSTALL_COMMAND $(MAKE) install
-)
+  )
+endif()
 
 # Set the paths so that those can be included by the targets.
 # We explicitly set the static library here, so that we link against that one.
-set( HTSLIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/genesis-htslib" )
+if(NOT DEFINED HTSLIB_DIR)
+  set( HTSLIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/genesis-htslib" )
+endif()
 set( HTSLIB_INCLUDE_DIR "${HTSLIB_DIR}/include" )
 set( HTSLIB_LINK_DIR    "${HTSLIB_DIR}/lib" )
 set( HTSLIB_LIBRARY     "${HTSLIB_DIR}/lib/libhts.a" )


### PR DESCRIPTION
This patch allows to call cmake with `-DHTSLIB_DIR=<path>` to give the path of an external htslib build.
This will make the work-in-progress [Genesis Nix package](https://github.com/bzizou/nixpkgs/tree/grenedalf/pkgs/by-name/gr/grenedalf) simpler (no more need of a patch) and more robust to Genesis upgrades.

See https://github.com/lczech/grenedalf/issues/19