### PR TITLE
Avoid NaN placement coordinates on zero-length branches

### DIFF
--- a/lib/genesis/placement/sample.cpp
+++ b/lib/genesis/placement/sample.cpp
@@ -166,7 +166,11 @@ Pquery& Sample::add( Pquery const& other )
         auto const& old_edge_data  = place.edge().data<PlacementEdgeData>();
         auto const edge_index      = place.edge().index();
         auto const old_edge_num    = old_edge_data.edge_num();
-        auto const rel_pos         = place.proximal_length / old_edge_data.branch_length;
+        double rel_pos = 0.0;
+        // Avoid NaN placement coordinates on zero-length branches
+        if( old_edge_data.branch_length > 0.0 ) {
+            rel_pos = place.proximal_length / old_edge_data.branch_length;
+        }
         place.reset_edge( tree().edge_at( edge_index ));
 
         // Now the placement points to the new edge. We can thus check if this one still has the


### PR DESCRIPTION
When copying placements between Samples, the relative branch position is calculated as

    place.proximal_length / old_edge_data.branch_length

For placements on zero-length branches this becomes 0.0 / 0.0, producing NaN. The NaN is subsequently propagated into the merged .jplace output.

This change treats zero-length branches as having a relative position of 0.0, preventing NaN placement coordinates while preserving placement location.

The issue was observed via gappa edit merge, where accumulated placements on a zero-length branch produced invalid JSON entries such as:

    [ 138, 0, 1, -nan, 1.99999 ]